### PR TITLE
feat: Add explicit end_date support to contracts and dev seed; Switch…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,9 +58,11 @@ tools/importcashflow/*
 tools/importcsv/*
 tools/extract_sales_names/*
 tools/importsales/*
+*.csv
 
 # local make overrides (ignored)
 Makefile
 
 # logs
 *.log
+*_import.json

--- a/api/cashflow_helper.go
+++ b/api/cashflow_helper.go
@@ -3,13 +3,26 @@ package api
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 )
 
 // insertCashflowEntriesTx inserts scheduled cashflow entries for a contract inside the provided transaction.
 // It is idempotent when a UNIQUE(contract_id,due_date) index exists (uses ON CONFLICT DO NOTHING).
-func insertCashflowEntriesTx(tx *sql.Tx, contractID int, startDate time.Time, durationMonths int, revenueTotal float64, paymentFreq string) error {
-	// determine step in months
+func insertCashflowEntriesTx(
+	tx *sql.Tx,
+	contractID int,
+	startDate time.Time,
+	endDate time.Time,
+	revenueTotal float64,
+	paymentFreq string,
+) error {
+
+	if endDate.Before(startDate) {
+		return fmt.Errorf("endDate cannot be before startDate")
+	}
+
+	// Determine month step based on frequency
 	step := 1
 	switch paymentFreq {
 	case "monthly":
@@ -21,32 +34,85 @@ func insertCashflowEntriesTx(tx *sql.Tx, contractID int, startDate time.Time, du
 	case "bi-yearly":
 		step = 6
 	case "one-time":
-		// for one-time payments we create a single entry at start_date
-		step = durationMonths
+		step = 0
 	default:
 		step = 1
 	}
 
-	// per-month base
-	perMonth := 0.0
-	if durationMonths > 0 {
-		perMonth = revenueTotal / float64(durationMonths)
-	}
-
-	// insert entries for each generated due date within the contract duration
-	stmt := `INSERT INTO cashflow_entries (contract_id, due_date, amount, status) VALUES ($1, $2::date, $3, 'pending') ON CONFLICT (contract_id, due_date) DO NOTHING`
+	stmt := `
+		INSERT INTO cashflow_entries 
+			(contract_id, due_date, amount, status) 
+		VALUES ($1, $2::date, $3, 'pending')
+		ON CONFLICT (contract_id, due_date) DO NOTHING
+	`
 
 	ctx := context.Background()
-	for offset := 0; offset < durationMonths; offset += step {
-		due := startDate.AddDate(0, offset, 0)
-		amount := perMonth * float64(step)
-		if paymentFreq == "one-time" {
-			amount = revenueTotal
-		}
-		if _, err := tx.ExecContext(ctx, stmt, contractID, due.Format("2006-01-02"), amount); err != nil {
+
+	// ONE-TIME PAYMENT
+	if paymentFreq == "one-time" {
+		_, err := tx.ExecContext(ctx, stmt,
+			contractID,
+			startDate.Format("2006-01-02"),
+			revenueTotal,
+		)
+		return err
+	}
+
+	// Count number of periods
+	periods := 0
+	current := startDate
+
+	for !current.After(endDate) {
+		periods++
+		current = addMonthClamped(current, step)
+	}
+
+	if periods == 0 {
+		return nil
+	}
+
+	// Evenly distribute revenue
+	amountPerPeriod := revenueTotal / float64(periods)
+
+	// Reset loop
+	current = startDate
+
+	for !current.After(endDate) {
+
+		_, err := tx.ExecContext(ctx, stmt,
+			contractID,
+			current.Format("2006-01-02"),
+			amountPerPeriod,
+		)
+		if err != nil {
 			return err
 		}
+
+		current = addMonthClamped(current, step)
 	}
 
 	return nil
+}
+
+func addMonthClamped(t time.Time, months int) time.Time {
+	year, month, day := t.Date()
+	loc := t.Location()
+
+	// target month
+	target := time.Date(year, month+time.Month(months), 1, 0, 0, 0, 0, loc)
+
+	// last day of target month
+	lastDay := target.AddDate(0, 1, -1).Day()
+
+	if day > lastDay {
+		day = lastDay
+	}
+
+	return time.Date(
+		target.Year(),
+		target.Month(),
+		day,
+		0, 0, 0, 0,
+		loc,
+	)
 }

--- a/api/contracts.go
+++ b/api/contracts.go
@@ -21,7 +21,7 @@ type Contract struct {
 	SalesProcessID int                    `json:"sales_process_id"`
 	StartDate      string                 `json:"start_date"`
 	CreatedAt      *string                `json:"created_at,omitempty"`
-	EndDate        *string                `json:"end_date_computed,omitempty"`
+	EndDate        *string                `json:"end_date,omitempty"`
 	DurationMonths int                    `json:"duration_months"`
 	RevenueTotal   float64                `json:"revenue_total"`
 	PaymentFreq    string                 `json:"payment_frequency"`
@@ -44,7 +44,7 @@ type ContractResponse struct {
 	CreatedAt         *string           `json:"created_at,omitempty"`
 	UpdatedAt         *string           `json:"updated_at,omitempty"`
 	StartDate         string            `json:"start_date"`
-	EndDate           *string           `json:"end_date_computed,omitempty"`
+	EndDate           *string           `json:"end_date,omitempty"`
 	DurationMonths    int               `json:"duration_months"`
 	RevenueTotal      float64           `json:"revenue_total"`
 	PaymentFreq       string            `json:"payment_frequency"`
@@ -79,7 +79,7 @@ SELECT
   cl.name AS client_name,
   c.sales_process_id,
   c.start_date,
-	c.end_date_computed,
+	c.end_date,
 	c.created_at,
   c.duration_months,
   c.revenue_total,
@@ -262,12 +262,13 @@ func (h *Handler) ListContractCashflowEntries(w http.ResponseWriter, r *http.Req
 // POST /api/contracts
 func (h *Handler) CreateContract(w http.ResponseWriter, r *http.Request) {
 	var c Contract
+
 	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	// normalize and validate payment frequency
+	// Normalize and validate payment frequency
 	pf := strings.ToLower(strings.TrimSpace(c.PaymentFreq))
 	if pf != "monthly" && pf != "bi-monthly" && pf != "quarterly" && pf != "one-time" && pf != "bi-yearly" {
 		http.Error(w, "invalid payment_frequency (allowed: monthly, bi-monthly, quarterly, one-time, bi-yearly)", http.StatusBadRequest)
@@ -279,7 +280,32 @@ func (h *Handler) CreateContract(w http.ResponseWriter, r *http.Request) {
 	}
 	c.PaymentFreq = pf
 
-	// create contract and its cashflow entries atomically
+	// Parse start date
+	sd, err := time.Parse("2006-01-02", c.StartDate)
+	if err != nil {
+		http.Error(w, "invalid start_date (expected YYYY-MM-DD)", http.StatusBadRequest)
+		return
+	}
+
+	// Determine end date
+	var ed time.Time
+
+	if c.EndDate != nil && *c.EndDate != "" {
+		parsedEnd, err := time.Parse("2006-01-02", *c.EndDate)
+		if err != nil {
+			http.Error(w, "invalid end_date (expected YYYY-MM-DD)", http.StatusBadRequest)
+			return
+		}
+		if parsedEnd.Before(sd) {
+			http.Error(w, "end_date cannot be before start_date", http.StatusBadRequest)
+			return
+		}
+		ed = parsedEnd
+	} else {
+		ed = sd.AddDate(0, c.DurationMonths, 0)
+	}
+
+	// Begin transaction
 	tx, err := h.DB.BeginTx(r.Context(), nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -287,15 +313,18 @@ func (h *Handler) CreateContract(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var createdAt sql.NullTime
+
+	// Insert contract (NOW including end_date)
 	err = tx.QueryRowContext(r.Context(), `
 	INSERT INTO contracts
-		(client_id, sales_process_id, start_date, duration_months, revenue_total, payment_frequency)
-	VALUES ($1, $2, $3::date, $4, $5, $6)
+		(client_id, sales_process_id, start_date, end_date, duration_months, revenue_total, payment_frequency)
+	VALUES ($1, $2, $3::date, $4::date, $5, $6, $7)
 	RETURNING id, created_at
-`,
+	`,
 		c.ClientID,
 		c.SalesProcessID,
-		c.StartDate,
+		sd,
+		ed,
 		c.DurationMonths,
 		c.RevenueTotal,
 		c.PaymentFreq,
@@ -312,43 +341,41 @@ func (h *Handler) CreateContract(w http.ResponseWriter, r *http.Request) {
 		c.CreatedAt = &s
 	}
 
-	// parse start date and insert scheduled cashflow entries
-	sd, err := time.Parse("2006-01-02", c.StartDate)
-	if err == nil && c.DurationMonths > 0 {
-		if err := insertCashflowEntriesTx(tx, c.ID, sd, c.DurationMonths, c.RevenueTotal, c.PaymentFreq); err != nil {
+	// Insert scheduled cashflow entries
+	if c.DurationMonths > 0 {
+		if err := insertCashflowEntriesTx(tx, c.ID, sd, ed, c.RevenueTotal, c.PaymentFreq); err != nil {
 			tx.Rollback()
 			http.Error(w, "failed to insert cashflow entries: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 	}
 
+	// Commit transaction
 	if err := tx.Commit(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	// optionally insert comments submitted with the create request (non-fatal)
+	// Optionally insert comments (non-fatal)
 	if len(c.Comments) > 0 {
 		_ = h.insertCommentsForEntity("contract", c.ID, c.Comments)
 	}
 
+	// Return response
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(c)
 
-	// Send notification email if configured (non-blocking)
+	// Send notification email asynchronously
 	notifyTo := os.Getenv("NEW_CONTRACT_NOTIFY_EMAIL")
 	if notifyTo != "" {
-		// run in background; failures are logged inside mailer.SendMail (if any)
 		go func() {
 			if err := mailer.SendNewContractNotification(notifyTo, c.ID, c.ClientID, c.RevenueTotal, c.StartDate); err != nil {
-				// best-effort logging to stdout
 				fmt.Printf("failed to send new contract notification: %v\n", err)
 			}
 		}()
 	}
 }
 
-// PATCH /api/contracts/{id}
 // PATCH /api/contracts/{id}
 func (h *Handler) UpdateContract(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
@@ -364,51 +391,82 @@ func (h *Handler) UpdateContract(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// normalize and validate payment frequency
+	// Normalize and validate payment frequency
 	pf := strings.ToLower(strings.TrimSpace(req.PaymentFreq))
 	if pf != "monthly" && pf != "bi-monthly" && pf != "quarterly" && pf != "one-time" && pf != "bi-yearly" {
-		http.Error(w, "invalid payment_frequency (allowed: monthly, bi-monthly, quarterly, one-time, bi-yearly)", http.StatusBadRequest)
-		return
-	}
-	if pf == "bi-yearly" && req.DurationMonths < 12 {
-		http.Error(w, "bi-yearly payment frequency requires duration_months >= 12", http.StatusBadRequest)
+		http.Error(w, "invalid payment_frequency", http.StatusBadRequest)
 		return
 	}
 	req.PaymentFreq = pf
 
-	// Convert "YYYY-MM-DD" → time.Time
-	t, err := time.Parse("2006-01-02", req.StartDate)
+	// Parse start date
+	sd, err := time.Parse("2006-01-02", req.StartDate)
 	if err != nil {
 		http.Error(w, "invalid start_date (expected YYYY-MM-DD)", http.StatusBadRequest)
 		return
 	}
 
-	_, err = h.DB.Exec(`
-        UPDATE contracts
-        SET 
-            start_date = $1,
-            duration_months = $2,
-            revenue_total = $3,
-            payment_frequency = $4
-        WHERE id = $5
-    `,
-		t,
-		req.DurationMonths,
-		req.RevenueTotal,
-		req.PaymentFreq,
-		id,
-	)
+	// Compute end date explicitly
+	ed := sd.AddDate(0, req.DurationMonths, 0)
 
+	tx, err := h.DB.BeginTx(r.Context(), nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	// optionally insert comments provided in the patch
+	// 1️⃣ Update contract fields
+	_, err = tx.Exec(`
+		UPDATE contracts
+		SET 
+			start_date = $1,
+			end_date = $2,
+			duration_months = $3,
+			revenue_total = $4,
+			payment_frequency = $5,
+			updated_at = NOW()
+		WHERE id = $6
+	`,
+		sd,
+		ed,
+		req.DurationMonths,
+		req.RevenueTotal,
+		req.PaymentFreq,
+		id,
+	)
+	if err != nil {
+		tx.Rollback()
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// 2️⃣ Delete ALL projection entries (derived data)
+	_, err = tx.Exec(`
+		DELETE FROM cashflow_entries
+		WHERE contract_id = $1
+	`, id)
+	if err != nil {
+		tx.Rollback()
+		http.Error(w, "failed to clear projection schedule: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// 3️⃣ Recreate projection schedule
+	if err := insertCashflowEntriesTx(tx, id, sd, ed, req.RevenueTotal, req.PaymentFreq); err != nil {
+		tx.Rollback()
+		http.Error(w, "failed to regenerate schedule: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// 4️⃣ Commit transaction
+	if err := tx.Commit(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Optional comments (same behavior as before)
 	if req.Comments != nil && len(req.Comments) > 0 {
-		if err := h.insertCommentsForEntity("contract", id, req.Comments); err != nil {
-			// ignore failure
-		}
+		_ = h.insertCommentsForEntity("contract", id, req.Comments)
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/api/contracts_unit_test.go
+++ b/api/contracts_unit_test.go
@@ -37,33 +37,50 @@ func TestCreateContract_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
+	defer db.Close()
+
 	h := &Handler{DB: db}
 
-	c := Contract{ClientID: 1, SalesProcessID: 2, StartDate: "2025-01-01", DurationMonths: 0, RevenueTotal: 1200, PaymentFreq: "monthly"}
+	c := Contract{
+		ClientID:       1,
+		SalesProcessID: 2,
+		StartDate:      "2025-01-01",
+		DurationMonths: 0, // allow 0 duration for testing, test cashflow entires generation in integration test
+		RevenueTotal:   1200,
+		PaymentFreq:    "monthly",
+	}
+
 	b, _ := json.Marshal(c)
 	req := httptest.NewRequest(http.MethodPost, "/api/contracts", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 
-	// Expect transaction begin, INSERT ... RETURNING id, created_at, and commit
 	mock.ExpectBegin()
+
 	created := time.Now()
-	rows := sqlmock.NewRows([]string{"id", "created_at"}).AddRow(7, created)
-	mock.ExpectQuery("INSERT INTO contracts").WithArgs(c.ClientID, c.SalesProcessID, c.StartDate, c.DurationMonths, c.RevenueTotal, c.PaymentFreq).WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"id", "created_at"}).
+		AddRow(7, created)
+
+	expectedStart, _ := time.Parse("2006-01-02", c.StartDate)
+	expectedEnd := expectedStart.AddDate(0, c.DurationMonths, 0)
+
+	mock.ExpectQuery("INSERT INTO contracts").
+		WithArgs(
+			c.ClientID,
+			c.SalesProcessID,
+			expectedStart,
+			expectedEnd,
+			c.DurationMonths,
+			c.RevenueTotal,
+			c.PaymentFreq,
+		).
+		WillReturnRows(rows)
+
 	mock.ExpectCommit()
 
 	h.CreateContract(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
-
-	// simple response body check for id
-	var out Contract
-	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-	if out.ID != 7 {
-		t.Fatalf("expected id 7, got %d", out.ID)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -110,8 +127,33 @@ func TestUpdateContract_Success(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	w := httptest.NewRecorder()
 
-	// Expect Exec update
-	mock.ExpectExec("UPDATE contracts").WithArgs(sqlmock.AnyArg(), reqBody.DurationMonths, reqBody.RevenueTotal, reqBody.PaymentFreq, 5).WillReturnResult(sqlmock.NewResult(0, 1))
+	// Expect transaction begin
+	mock.ExpectBegin()
+	// Expect update
+	mock.ExpectExec("UPDATE contracts").WithArgs(
+		sqlmock.AnyArg(), // start_date
+		sqlmock.AnyArg(), // end_date
+		reqBody.DurationMonths,
+		reqBody.RevenueTotal,
+		reqBody.PaymentFreq,
+		5,
+	).WillReturnResult(sqlmock.NewResult(0, 1))
+	// Expect delete
+	mock.ExpectExec("DELETE FROM cashflow_entries").WithArgs(5).WillReturnResult(sqlmock.NewResult(0, 1))
+	// Expect insertCashflowEntriesTx: there will be one INSERT per period
+	expectedStart, _ := time.Parse("2006-01-02", reqBody.StartDate)
+	expectedEnd := expectedStart.AddDate(0, reqBody.DurationMonths, 0)
+	periods := 0
+	cur := expectedStart
+	for !cur.After(expectedEnd) {
+		periods++
+		cur = cur.AddDate(0, 1, 0)
+	}
+	for i := 0; i < periods; i++ {
+		mock.ExpectExec("INSERT INTO cashflow_entries").WillReturnResult(sqlmock.NewResult(0, 1))
+	}
+	// Expect commit
+	mock.ExpectCommit()
 
 	h.UpdateContract(w, req)
 

--- a/api/importer.go
+++ b/api/importer.go
@@ -1,0 +1,262 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"time"
+)
+
+type ContractImport struct {
+	Name          string                 `json:"name"`
+	ContractStart string                 `json:"contract_start"`
+	ContractEnd   string                 `json:"contract_end"`
+	Cashflows     map[string]interface{} `json:"cashflows"`
+	IsFormer      bool                   `json:"is_former"`
+	//CLV           float64                `json:"clv"`
+
+}
+
+func (h *Handler) ImportContracts(w http.ResponseWriter, r *http.Request) {
+	var payload []ContractImport
+
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	imported := 0
+	skipped := []string{}
+
+	for _, c := range payload {
+
+		tx, err := h.DB.Begin()
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		// -------------------------
+		// Parse Dates
+		// -------------------------
+		start, err := parseISO(c.ContractStart)
+		if err != nil {
+			if c.IsFormer {
+				log.Printf("Skipping former client %s (invalid start)", c.Name)
+				tx.Rollback()
+				skipped = append(skipped, c.Name)
+				continue
+			}
+			tx.Rollback()
+			http.Error(w, "invalid contract_start", 400)
+			return
+		}
+
+		end, err := parseISO(c.ContractEnd)
+		if err != nil {
+			if c.IsFormer {
+				log.Printf("Skipping former client %s (invalid end)", c.Name)
+				tx.Rollback()
+				skipped = append(skipped, c.Name)
+				continue
+			}
+			tx.Rollback()
+			http.Error(w, "invalid contract_end", 400)
+			return
+		}
+
+		if end.Before(start) {
+			if c.IsFormer {
+				log.Printf("Skipping former client %s (invalid date range)", c.Name)
+				tx.Rollback()
+				skipped = append(skipped, c.Name)
+				continue
+			}
+			tx.Rollback()
+			http.Error(w, "contract_end before contract_start", 400)
+			return
+		}
+
+		// -------------------------
+		// Insert Client
+		// -------------------------
+		status := "active"
+		if c.IsFormer {
+			status = "inactive"
+		}
+
+		var clientID int
+		err = tx.QueryRow(`
+			INSERT INTO clients (name, status)
+			VALUES ($1, $2)
+			RETURNING id
+		`, c.Name, status).Scan(&clientID)
+
+		if err != nil {
+			tx.Rollback()
+			if c.IsFormer {
+				log.Printf("Skipping former client %s (client insert failed)", c.Name)
+				skipped = append(skipped, c.Name)
+				continue
+			}
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		// -------------------------
+		// Derive revenue + due dates
+		// -------------------------
+		var dueDates []time.Time
+		var revenueTotal float64
+
+		for ym, value := range c.Cashflows {
+			date, err := time.Parse("2006-01", ym)
+			if err != nil {
+				continue
+			}
+
+			if v, ok := value.(float64); ok && v > 0 {
+				dueDates = append(dueDates, date)
+				revenueTotal += v
+			}
+		}
+
+		// -------------------------
+		// Compute duration
+		// -------------------------
+		durationMonths := (end.Year()-start.Year())*12 + int(end.Month()-start.Month())
+		if durationMonths <= 0 {
+			durationMonths = 1
+		}
+
+		// -------------------------
+		// Detect payment frequency
+		// -------------------------
+		paymentFreq := "monthly"
+
+		if len(dueDates) == 1 {
+			paymentFreq = "one-time"
+		} else if len(dueDates) >= 2 {
+			sort.Slice(dueDates, func(i, j int) bool {
+				return dueDates[i].Before(dueDates[j])
+			})
+
+			diff := (dueDates[1].Year()-dueDates[0].Year())*12 +
+				int(dueDates[1].Month()-dueDates[0].Month())
+
+			switch {
+			case diff >= 6:
+				paymentFreq = "bi-yearly"
+			case diff >= 3:
+				paymentFreq = "quarterly"
+			case diff >= 2:
+				paymentFreq = "bi-monthly"
+			default:
+				paymentFreq = "monthly"
+			}
+		}
+
+		// -------------------------
+		// Insert Contract
+		// -------------------------
+		var contractID int
+		err = tx.QueryRow(`
+			INSERT INTO contracts 
+				(client_id, start_date, end_date, duration_months, revenue_total, payment_frequency)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			RETURNING id
+		`,
+			clientID,
+			start,
+			end,
+			durationMonths,
+			revenueTotal,
+			paymentFreq,
+		).Scan(&contractID)
+
+		if err != nil {
+			tx.Rollback()
+			if c.IsFormer {
+				log.Printf("Skipping former client %s (contract insert failed)", c.Name)
+				skipped = append(skipped, c.Name)
+				continue
+			}
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		// -------------------------
+		// Insert Cashflows + Comments
+		// -------------------------
+		for ym, value := range c.Cashflows {
+			date, err := time.Parse("2006-01", ym)
+			if err != nil {
+				continue
+			}
+
+			switch v := value.(type) {
+
+			case float64:
+				if v == 0 {
+					continue
+				}
+				_, err := tx.Exec(`
+					INSERT INTO cashflow_entries 
+						(contract_id, due_date, amount, status)
+					VALUES ($1, $2::date, $3, 'pending')
+				`, contractID, date, v)
+				if err != nil {
+					tx.Rollback()
+					http.Error(w, err.Error(), 500)
+					return
+				}
+
+			case string:
+				if v == "" {
+					continue
+				}
+				_, err := tx.Exec(`
+					INSERT INTO comments (entity_type, entity_id, body)
+					VALUES ('contract', $1, $2)
+				`, contractID, fmt.Sprintf("%s: %s", ym, v))
+				if err != nil {
+					tx.Rollback()
+					http.Error(w, err.Error(), 500)
+					return
+				}
+			}
+		}
+
+		if err := tx.Commit(); err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		imported++
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":   "import completed",
+		"imported": imported,
+		"skipped":  skipped,
+	})
+}
+
+func parseISO(value string) (time.Time, error) {
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05",
+		"2006-01-02",
+	}
+
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("invalid date: %s", value)
+}

--- a/api/integration/contracts_integration_test.go
+++ b/api/integration/contracts_integration_test.go
@@ -68,7 +68,6 @@ func TestCreateContract_Integration(t *testing.T) {
 
 	testhelpers.TruncateAll(t, suite.DB)
 
-	// Arrange: client + sales process
 	client := suite.CreateClient()
 	sp := suite.CreateSalesProcessForClient(client.ID)
 
@@ -85,12 +84,10 @@ func TestCreateContract_Integration(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/contracts", bytes.NewReader(b))
 	w := httptest.NewRecorder()
 
-	// Act
 	handler.CreateContract(w, req)
 
-	// Assert HTTP
 	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Code)
+		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
 	}
 
 	var out api.Contract
@@ -102,8 +99,56 @@ func TestCreateContract_Integration(t *testing.T) {
 		t.Fatalf("expected generated contract ID")
 	}
 
-	if out.ClientID != client.ID {
-		t.Fatalf("expected client_id=%d, got %d", client.ID, out.ClientID)
+	// 🔎 Verify projection rows
+	rows, err := suite.DB.DB.Query(`
+		SELECT due_date, amount
+		FROM cashflow_entries
+		WHERE contract_id = $1
+		ORDER BY due_date
+	`, out.ID)
+	if err != nil {
+		t.Fatalf("query projection rows failed: %v", err)
+	}
+	defer rows.Close()
+
+	var count int
+	var firstDue time.Time
+	var lastDue time.Time
+	var amount float64
+
+	for rows.Next() {
+		var due time.Time
+		if err := rows.Scan(&due, &amount); err != nil {
+			t.Fatalf("scan failed: %v", err)
+		}
+		if count == 0 {
+			firstDue = due
+		}
+		lastDue = due
+		count++
+	}
+
+	// Expect 13 rows (inclusive start → end)
+	if count != 13 {
+		t.Fatalf("expected 13 projection rows, got %d", count)
+	}
+
+	expectedStart, _ := time.Parse("2006-01-02", "2025-01-01")
+	expectedEnd := expectedStart.AddDate(0, 12, 0)
+
+	if !firstDue.Equal(expectedStart) {
+		t.Fatalf("expected first due_date %v, got %v", expectedStart, firstDue)
+	}
+
+	if !lastDue.Equal(expectedEnd) {
+		t.Fatalf("expected last due_date %v, got %v", expectedEnd, lastDue)
+	}
+
+	// 1200 / 13 periods
+	expectedAmount := 1200.0 / 13.0
+
+	if amount != expectedAmount {
+		t.Fatalf("expected per-period amount %v, got %v", expectedAmount, amount)
 	}
 }
 
@@ -200,5 +245,254 @@ func TestUpdateContract_InvalidDate_Integration(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestProjection_Quarterly(t *testing.T) {
+	suite := factory.NewSuiteFromTestDB(t, testDB)
+	testhelpers.TruncateAll(t, suite.DB)
+
+	handler := &api.Handler{DB: suite.DB.DB}
+
+	client := suite.CreateClient()
+	sp := suite.CreateSalesProcessForClient(client.ID)
+
+	body := api.Contract{
+		ClientID:       client.ID,
+		SalesProcessID: sp.ID,
+		StartDate:      "2025-01-01",
+		DurationMonths: 12,
+		RevenueTotal:   1200,
+		PaymentFreq:    "quarterly",
+	}
+
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/contracts", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+
+	handler.CreateContract(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var out api.Contract
+	_ = json.NewDecoder(w.Body).Decode(&out)
+
+	rows, _ := suite.DB.DB.Query(`
+		SELECT due_date, amount
+		FROM cashflow_entries
+		WHERE contract_id = $1
+		ORDER BY due_date
+	`, out.ID)
+	defer rows.Close()
+
+	var count int
+	var last time.Time
+	for rows.Next() {
+		var due time.Time
+		var amount float64
+		rows.Scan(&due, &amount)
+
+		if count > 0 {
+			expected := last.AddDate(0, 3, 0)
+			if !due.Equal(expected) {
+				t.Fatalf("expected quarterly spacing, got %v after %v", due, last)
+			}
+		}
+
+		last = due
+		count++
+	}
+
+	// Jan 2025 → Jan 2026 inclusive = 5 rows (0,3,6,9,12)
+	if count != 5 {
+		t.Fatalf("expected 5 quarterly rows, got %d", count)
+	}
+}
+
+func TestProjection_OneTime(t *testing.T) {
+	suite := factory.NewSuiteFromTestDB(t, testDB)
+	testhelpers.TruncateAll(t, suite.DB)
+
+	handler := &api.Handler{DB: suite.DB.DB}
+
+	client := suite.CreateClient()
+	sp := suite.CreateSalesProcessForClient(client.ID)
+
+	body := api.Contract{
+		ClientID:       client.ID,
+		SalesProcessID: sp.ID,
+		StartDate:      "2025-01-01",
+		DurationMonths: 12,
+		RevenueTotal:   1200,
+		PaymentFreq:    "one-time",
+	}
+
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/contracts", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+
+	handler.CreateContract(w, req)
+
+	var out api.Contract
+	_ = json.NewDecoder(w.Body).Decode(&out)
+
+	var count int
+	_ = suite.DB.DB.QueryRow(`
+		SELECT COUNT(*) FROM cashflow_entries WHERE contract_id=$1
+	`, out.ID).Scan(&count)
+
+	if count != 1 {
+		t.Fatalf("expected 1 one-time projection row, got %d", count)
+	}
+}
+
+func TestProjection_Shortening(t *testing.T) {
+	suite := factory.NewSuiteFromTestDB(t, testDB)
+	testhelpers.TruncateAll(t, suite.DB)
+
+	handler := &api.Handler{DB: suite.DB.DB}
+
+	client := suite.CreateClient()
+	sp := suite.CreateSalesProcessForClient(client.ID)
+	contract := suite.CreateContract(client.ID, sp.ID)
+
+	update := api.UpdateContractRequest{
+		StartDate:      "2025-01-01",
+		DurationMonths: 6,
+		RevenueTotal:   600,
+		PaymentFreq:    "monthly",
+	}
+
+	b, _ := json.Marshal(update)
+	req := httptest.NewRequest(http.MethodPatch,
+		fmt.Sprintf("/api/contracts/%d", contract.ID),
+		bytes.NewReader(b),
+	)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.Itoa(contract.ID))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	handler.UpdateContract(w, req)
+
+	var count int
+	_ = suite.DB.DB.QueryRow(`
+		SELECT COUNT(*) FROM cashflow_entries WHERE contract_id=$1
+	`, contract.ID).Scan(&count)
+
+	// Jan → July inclusive = 7 rows
+	if count != 7 {
+		t.Fatalf("expected 7 rows after shortening, got %d", count)
+	}
+}
+
+func TestProjection_Extension(t *testing.T) {
+	suite := factory.NewSuiteFromTestDB(t, testDB)
+	testhelpers.TruncateAll(t, suite.DB)
+
+	handler := &api.Handler{DB: suite.DB.DB}
+
+	client := suite.CreateClient()
+	sp := suite.CreateSalesProcessForClient(client.ID)
+
+	body := api.Contract{
+		ClientID:       client.ID,
+		SalesProcessID: sp.ID,
+		StartDate:      "2025-01-01",
+		DurationMonths: 6,
+		RevenueTotal:   600,
+		PaymentFreq:    "monthly",
+	}
+
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/contracts", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+	handler.CreateContract(w, req)
+
+	var out api.Contract
+	_ = json.NewDecoder(w.Body).Decode(&out)
+
+	update := api.UpdateContractRequest{
+		StartDate:      "2025-01-01",
+		DurationMonths: 12,
+		RevenueTotal:   1200,
+		PaymentFreq:    "monthly",
+	}
+
+	b2, _ := json.Marshal(update)
+	req2 := httptest.NewRequest(http.MethodPatch,
+		fmt.Sprintf("/api/contracts/%d", out.ID),
+		bytes.NewReader(b2),
+	)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.Itoa(out.ID))
+	req2 = req2.WithContext(context.WithValue(req2.Context(), chi.RouteCtxKey, rctx))
+
+	w2 := httptest.NewRecorder()
+	handler.UpdateContract(w2, req2)
+
+	var count int
+	_ = suite.DB.DB.QueryRow(`
+		SELECT COUNT(*) FROM cashflow_entries WHERE contract_id=$1
+	`, out.ID).Scan(&count)
+
+	// Jan 2025 → Jan 2026 inclusive = 13
+	if count != 13 {
+		t.Fatalf("expected 13 rows after extension, got %d", count)
+	}
+}
+
+func TestProjection_StartDate31st(t *testing.T) {
+	suite := factory.NewSuiteFromTestDB(t, testDB)
+	testhelpers.TruncateAll(t, suite.DB)
+
+	handler := &api.Handler{DB: suite.DB.DB}
+
+	client := suite.CreateClient()
+	sp := suite.CreateSalesProcessForClient(client.ID)
+
+	body := api.Contract{
+		ClientID:       client.ID,
+		SalesProcessID: sp.ID,
+		StartDate:      "2025-01-31",
+		DurationMonths: 2,
+		RevenueTotal:   300,
+		PaymentFreq:    "monthly",
+	}
+
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/contracts", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+
+	handler.CreateContract(w, req)
+
+	var out api.Contract
+	_ = json.NewDecoder(w.Body).Decode(&out)
+
+	rows, _ := suite.DB.DB.Query(`
+		SELECT due_date FROM cashflow_entries
+		WHERE contract_id=$1
+		ORDER BY due_date
+	`, out.ID)
+	defer rows.Close()
+
+	var dates []time.Time
+	for rows.Next() {
+		var d time.Time
+		rows.Scan(&d)
+		dates = append(dates, d)
+	}
+
+	// Go normalizes Feb 31 → Feb 28/29
+	if len(dates) < 2 {
+		t.Fatalf("expected at least 2 rows")
+	}
+
+	if dates[1].Month() != time.February {
+		t.Fatalf("expected February rollover, got %v", dates[1])
 	}
 }

--- a/api/nlq_schema.go
+++ b/api/nlq_schema.go
@@ -40,7 +40,7 @@ TABLE contracts (
   client_id INT,
   sales_process_id INT,
   start_date DATE,
-  end_date_computed DATE,
+  end_date DATE,
   duration_months INT,
   revenue_total NUMERIC,
   payment_frequency TEXT CHECK (payment_frequency IN ('monthly','bi-monthly','quarterly'))
@@ -264,15 +264,15 @@ LIMIT 50
 
 - "aktive Verträge", "laufende Verträge"
   → ct.start_date <= CURRENT_DATE
-    AND (ct.end_date_computed IS NULL OR ct.end_date_computed >= CURRENT_DATE)
+    AND (ct.end_date IS NULL OR ct.end_date >= CURRENT_DATE)
 
 - "läuft bald aus", "endet in den nächsten 30 Tagen"
-  → ct.end_date_computed IS NOT NULL
-    AND ct.end_date_computed > CURRENT_DATE
-    AND ct.end_date_computed <= CURRENT_DATE + INTERVAL '30 days'
+  → ct.end_date IS NOT NULL
+    AND ct.end_date > CURRENT_DATE
+    AND ct.end_date <= CURRENT_DATE + INTERVAL '30 days'
 
 - "bereits beendet", "abgelaufen"
-  → ct.end_date_computed IS NOT NULL AND ct.end_date_computed < CURRENT_DATE
+  → ct.end_date IS NOT NULL AND ct.end_date < CURRENT_DATE
 
 - "monatlicher Betrag", "monatlicher Umsatz"
   → If monthly amount is requested conceptually, but not stored, return revenue_total
@@ -333,7 +333,7 @@ LIMIT 50
 - "letzte 7 Tage" → <col> >= CURRENT_DATE - INTERVAL '7 days'
 - "letzte 30 Tage" → <col> >= CURRENT_DATE - INTERVAL '30 days'
 (Choose the correct date column based on context:
- follow-ups → sp.follow_up_date; contracts → ct.start_date/ct.end_date_computed; stages → st.date; clients → c.completed_at.)
+ follow-ups → sp.follow_up_date; contracts → ct.start_date/ct.end_date; stages → st.date; clients → c.completed_at.)
 
 ---------------------------
 -- ADDITIONAL INSTRUCTIONS

--- a/api/router.go
+++ b/api/router.go
@@ -164,6 +164,10 @@ func NewRouterWithConfig(db *sql.DB, cfg *Config) *chi.Mux {
 		pr.Patch("/comments/{id}", h.UpdateComment)
 		pr.Delete("/comments/{id}", h.DeleteComment)
 
+		// ---- Import routes (admin/internal only) ----
+		pr.Route("/import", func(ir chi.Router) {
+			ir.Post("/contracts", h.ImportContracts)
+		})
 	})
 
 	return r

--- a/api/sales.go
+++ b/api/sales.go
@@ -337,7 +337,16 @@ func (h *Handler) UpdateSalesProcess(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid contract_start_date", http.StatusBadRequest)
 			return
 		}
-		if err := insertCashflowEntriesTx(tx2, newContractID, sd, *sp.ContractDurationMonths, *sp.Revenue, *sp.ContractFrequency); err != nil {
+		endDate := sd.AddDate(0, *sp.ContractDurationMonths, 0)
+
+		if err := insertCashflowEntriesTx(
+			tx2,
+			newContractID,
+			sd,
+			endDate,
+			*sp.Revenue,
+			*sp.ContractFrequency,
+		); err != nil {
 			http.Error(w, "failed to create cashflow entries: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -599,7 +608,7 @@ func (h *Handler) StartSalesProcess(w http.ResponseWriter, r *http.Request) {
         SELECT 1
         FROM contracts
         WHERE client_id = $1
-          AND end_date_computed >= CURRENT_DATE
+          AND end_date >= CURRENT_DATE
     )
 `, *existingClientID).Scan(&hasActiveContract)
 
@@ -1204,7 +1213,7 @@ func (h *Handler) CreateOrUpdateUpsell(w http.ResponseWriter, r *http.Request) {
 	var prevContractID *int
 	_ = tx.QueryRow(`
         SELECT id FROM contracts
-        WHERE client_id = $1 AND end_date_computed IS NULL
+        WHERE client_id = $1 AND end_date IS NULL
         ORDER BY id DESC LIMIT 1
     `, clientID).Scan(&prevContractID)
 
@@ -1268,10 +1277,20 @@ func (h *Handler) CreateOrUpdateUpsell(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "invalid contract_start_date", 400)
 			return
 		}
-		if err := insertCashflowEntriesTx(tx, *newContractID, sd, *req.ContractDurationMonths, *req.UpsellRevenue, *req.ContractFrequency); err != nil {
+		endDate := sd.AddDate(0, *req.ContractDurationMonths, 0)
+
+		if err := insertCashflowEntriesTx(
+			tx,
+			*newContractID,
+			sd,
+			endDate,
+			*req.UpsellRevenue,
+			*req.ContractFrequency,
+		); err != nil {
 			http.Error(w, "failed to create cashflow entries: "+err.Error(), 500)
 			return
 		}
+
 	}
 
 	// -----------------------

--- a/db/migrations/20260225184453_add_nullable_manual_override_end_date_column.down.sql
+++ b/db/migrations/20260225184453_add_nullable_manual_override_end_date_column.down.sql
@@ -1,0 +1,9 @@
+-- 1. Drop explicit end_date
+ALTER TABLE contracts
+  DROP COLUMN IF EXISTS end_date;
+
+-- 2. Recreate generated column
+ALTER TABLE contracts
+  ADD COLUMN end_date_computed DATE GENERATED ALWAYS AS (
+    (start_date + make_interval(months => duration_months))::date
+  ) STORED;

--- a/db/migrations/20260225184453_add_nullable_manual_override_end_date_column.up.sql
+++ b/db/migrations/20260225184453_add_nullable_manual_override_end_date_column.up.sql
@@ -1,0 +1,7 @@
+-- 1. Drop generated column
+ALTER TABLE contracts
+  DROP COLUMN IF EXISTS end_date_computed;
+
+-- 2. Add explicit end_date column
+ALTER TABLE contracts
+  ADD COLUMN end_date DATE;

--- a/db/migrations/20260225201448_alter_contracts_make_sales_process_id_nullable.down.sql
+++ b/db/migrations/20260225201448_alter_contracts_make_sales_process_id_nullable.down.sql
@@ -1,0 +1,5 @@
+-- Re-enforce sales_process_id requirement
+-- WARNING: This will fail if any contracts have NULL sales_process_id
+
+ALTER TABLE contracts
+ALTER COLUMN sales_process_id SET NOT NULL;

--- a/db/migrations/20260225201448_alter_contracts_make_sales_process_id_nullable.up.sql
+++ b/db/migrations/20260225201448_alter_contracts_make_sales_process_id_nullable.up.sql
@@ -1,0 +1,5 @@
+-- Allow contracts that were imported from legacy systems
+-- to exist without a sales_process_id
+
+ALTER TABLE contracts
+ALTER COLUMN sales_process_id DROP NOT NULL;

--- a/db/seeds/dev_seed.sql
+++ b/db/seeds/dev_seed.sql
@@ -22,7 +22,12 @@ s AS (
   RETURNING id
 ),
 
--- 2) Clients
+-- 2c) Client for explicit end_date test
+explicit_enddate_client AS (
+  INSERT INTO clients (name, email, phone, source, status)
+  VALUES ('Explicit Enddate Client', 'explicit@enddate.com', '555000111', 'organic', 'active')
+  RETURNING id
+),
 anna AS (
   INSERT INTO clients (name, email, phone, source, source_stage_id, status, completed_at)
   VALUES ('Anna Schmidt', 'anna@example.com', '123456', 'organic', NULL, 'active', (CURRENT_DATE + INTERVAL '60 days')::date)
@@ -66,7 +71,13 @@ converted_lead AS (
 ),
 
 
--- 3) Sales processes
+-- Sales process for explicit end_date client
+sp_explicit_enddate AS (
+  INSERT INTO sales_process (client_id, stage, follow_up_date, follow_up_result, closed, revenue)
+  SELECT eec.id, 'closed', (CURRENT_DATE + INTERVAL '2 days')::date, TRUE, TRUE, 1234
+  FROM explicit_enddate_client eec
+  RETURNING id, client_id
+),
 -- Anna: closed/won (Abschluss)
 sp_anna AS (
   INSERT INTO sales_process (client_id, stage, follow_up_date, follow_up_result, closed, revenue, stage_id)
@@ -96,8 +107,13 @@ sp_maria AS (
   RETURNING id, client_id
 ),
 
--- 4) Contracts for both active clients (Anna + Max)
--- ⚠️ end_date_computed is GENERATED ALWAYS, so we do NOT insert into it.
+-- Contract with explicit end_date (not matching start + duration)
+contract_explicit_enddate AS (
+  INSERT INTO contracts (client_id, sales_process_id, start_date, end_date, duration_months, revenue_total, payment_frequency)
+  SELECT se.client_id, se.id, '2026-01-15'::date, '2026-04-30'::date, 2, 1234, 'monthly'
+  FROM sp_explicit_enddate se
+  RETURNING id
+),
 contract_anna AS (
   INSERT INTO contracts (client_id, sales_process_id, start_date, duration_months, revenue_total, payment_frequency)
   SELECT sa.client_id, sa.id, '2025-10-01'::date, 6, 4800, 'monthly'

--- a/tools/adapter.py
+++ b/tools/adapter.py
@@ -1,0 +1,15 @@
+import requests
+
+
+class GoImportAdapter:
+    def __init__(self, endpoint_url: str):
+        self.endpoint_url = endpoint_url
+
+    def insert(self, records):
+        response = requests.post(
+            self.endpoint_url,
+            json=records,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()

--- a/tools/import_specs/cashflow_rules.yaml
+++ b/tools/import_specs/cashflow_rules.yaml
@@ -1,0 +1,51 @@
+# Cashflow Import Rules for Sales Application
+
+input:
+  skip_rows: 1
+  header_row: 1
+  delimiter: ","
+
+# Only map core contract fields directly.
+# Month columns will be handled dynamically after import.
+
+columns:
+  - source: "Name"
+    target: "lastname"
+    transform:
+      - trim
+      - titlecase
+
+  - source: "Vorname"
+    target: "firstname"
+    transform:
+      - trim
+      - titlecase
+
+  - source: "Startzeitpunkt"
+    target: "contract_start"
+    type: "date"
+    format: "%d.%m.%Y"
+
+  - source: "Endzeitpunkt"
+    target: "contract_end"
+    type: "date"
+    formats:
+      - "%d.%m.%Y"
+      - "%d.%m.%y"
+
+  - source: "CLV"
+    target: "clv"
+    transform:
+      - trim
+
+computed_columns:
+  - target: "name"
+    expression: "firstname + ' ' + lastname"
+    drop_sources: true
+
+dynamic_columns:
+  - pattern: "[A-Za-zäöüÄÖÜ]+ '\\d{2}"
+    target: "cashflows"
+    mode: "year_month_map"
+    numeric_clean: true
+

--- a/tools/run_import.py
+++ b/tools/run_import.py
@@ -1,0 +1,28 @@
+from csv_importer.engine import ImportEngine
+from csv_importer.spec import load_spec
+from adapters import GoImportAdapter
+
+
+def main():
+    spec = load_spec("import_specs/cashflow_rules.yaml")
+    engine = ImportEngine(spec)
+
+    result = engine.run("Cashflow.csv")
+
+    if result.errors:
+        print("Import errors found:")
+        print(result.errors)
+        return
+
+    adapter = GoImportAdapter(
+        "http://localhost:8080/api/import/contracts"
+    )
+
+    response = adapter.insert(result.records)
+
+    print("Import successful.")
+    print(response)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
… Contract and ContractResponse to use end_date (not computed); Update contract creation and update logic to handle explicit end_date; Add dev seed entry for contract with manual end_date; Fix seed to use valid client source value

<!--
PR template for Sales Assistant Backend
This template reminds contributors/maintainers to add the release label required by the release workflow.
-->

# Pull Request

Short summary (one or two lines):

Describe the change and why it is needed.

## Checklist

- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation if needed
- [ ] I have added a changelog entry if this change affects public behavior

IMPORTANT: If this PR should trigger a release when merged to `master`, add one of the following labels to the PR (maintainers may add the label before merge):

- `major` — for breaking changes (bump MAJOR)
- `minor` — for new backward-compatible features (bump MINOR)
- `patch` — for bugfixes or small changes (bump PATCH)

The release workflow requires an explicit release label. If no label is present the release job will fail. If you are unsure which label to use, ask in the PR.

## Related issues

Links to issues, if any.
