### PR TITLE
fix: stage_id now correctly propagates through sales process lifecycle

### DIFF
--- a/api/sales.go
+++ b/api/sales.go
@@ -57,6 +57,7 @@ type SalesProcessUpdateRequest struct {
 	FollowUpResult         *bool                  `json:"follow_up_result"`
 	Closed                 *bool                  `json:"closed"`
 	Revenue                *float64               `json:"revenue"`
+	StageID                *int                   `json:"stage_id,omitempty"`
 	ContractDurationMonths *int                   `json:"contract_duration_months,omitempty"`
 	ContractStartDate      *string                `json:"contract_start_date,omitempty"`
 	ContractFrequency      *string                `json:"contract_frequency,omitempty"`
@@ -82,7 +83,7 @@ func (h *Handler) ListSalesProcesses(w http.ResponseWriter, r *http.Request) {
 		sp.follow_up_result,
 		sp.closed,
 		CASE WHEN COALESCE(sp.closed, false) THEN sp.revenue ELSE NULL END AS revenue,
-		sp.stage_id,
+		COALESCE(sp.stage_id, cl.source_stage_id) AS stage_id,
 		sp.lead_id
 	FROM sales_process sp
 	JOIN clients cl ON cl.id = sp.client_id
@@ -265,6 +266,7 @@ func (h *Handler) UpdateSalesProcess(w http.ResponseWriter, r *http.Request) {
 			WHEN $4 IS FALSE THEN NULL
 			ELSE revenue
 		END,
+		stage_id             = COALESCE($7, stage_id),
 		stage = CASE
 			-- A no-show ends the process (UI can’t reschedule), mark as lost.
 			WHEN COALESCE($3, follow_up_result) IS FALSE THEN 'lost'
@@ -284,6 +286,7 @@ func (h *Handler) UpdateSalesProcess(w http.ResponseWriter, r *http.Request) {
 		sp.Closed,
 		sp.Revenue,
 		id,
+		sp.StageID,
 	)
 
 	if err != nil {

--- a/api/sales_start.go
+++ b/api/sales_start.go
@@ -213,11 +213,20 @@ func (h *Handler) runStartSalesProcessTx(ctx context.Context, req StartSalesProc
 	).Scan(&salesID)
 
 	if err == sql.ErrNoRows {
+		// Conflict: reuse the existing sales_process but update stage_id if the new request provides one.
 		if err := tx.QueryRowContext(ctx,
 			`SELECT id FROM sales_process WHERE client_id = $1`,
 			clientID,
 		).Scan(&salesID); err != nil {
 			return 0, 0, "", nil, fmt.Errorf("sales_process reuse failed: %w", err)
+		}
+		if req.SourceStageID != nil {
+			if _, err := tx.ExecContext(ctx,
+				`UPDATE sales_process SET stage_id = $1 WHERE id = $2 AND stage_id IS NULL`,
+				req.SourceStageID, salesID,
+			); err != nil {
+				return 0, 0, "", nil, fmt.Errorf("sales_process stage_id backfill failed: %w", err)
+			}
 		}
 	} else if err != nil {
 		return 0, 0, "", nil, fmt.Errorf("sales_process insert failed: %w", err)

--- a/api/sales_unit_test.go
+++ b/api/sales_unit_test.go
@@ -288,7 +288,7 @@ func TestUpdateSalesProcess_NoShowForcesClosedFalseAndClearsCompletedAt(t *testi
 
 	// 1) UPDATE sales_process
 	mock.ExpectExec("UPDATE sales_process").
-		WithArgs(nil, nil, false, false, nil, 1).
+		WithArgs(nil, nil, false, false, nil, 1, nil).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// 2) Load client_id for completed_at updates
@@ -369,6 +369,99 @@ func TestUpdateSalesProcess_NoShowForcesClosedFalseAndClearsCompletedAt(t *testi
 	}
 }
 
+func TestUpdateSalesProcess_WithStageID_UpdatesStageLink(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	h := &Handler{DB: db}
+
+	stageID := 7
+	reqBody := SalesProcessUpdateRequest{StageID: &stageID}
+	b, _ := json.Marshal(reqBody)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/sales/1", bytes.NewReader(b))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	// 1) UPDATE sales_process includes $7 stage_id parameter.
+	mock.ExpectExec("UPDATE sales_process").
+		WithArgs(nil, nil, nil, nil, nil, 1, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 2) Resolve client_id for downstream sync.
+	mock.ExpectQuery("SELECT client_id FROM sales_process WHERE id = ").
+		WithArgs(1).
+		WillReturnRows(sqlmock.NewRows([]string{"client_id"}).AddRow(10))
+
+	// 3) Sync client status.
+	mock.ExpectExec("UPDATE clients c").
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 4) Return updated row with stage_id=7.
+	respCols := []string{
+		"id",
+		"client_id",
+		"client_name",
+		"client_email",
+		"client_phone",
+		"client_source",
+		"completed_at",
+		"stage",
+		"initial_contact_date",
+		"follow_up_date",
+		"follow_up_result",
+		"closed",
+		"revenue",
+		"stage_id",
+	}
+	respRows := sqlmock.NewRows(respCols).
+		AddRow(
+			1,
+			10,
+			"Client X",
+			sql.NullString{Valid: false},
+			sql.NullString{Valid: false},
+			sql.NullString{String: "paid", Valid: true},
+			sql.NullTime{Valid: false},
+			"follow_up",
+			"2026-03-01",
+			"2026-03-03",
+			sql.NullBool{Valid: false},
+			sql.NullBool{Valid: false},
+			sql.NullFloat64{Valid: false},
+			sql.NullInt64{Int64: 7, Valid: true},
+		)
+	mock.ExpectQuery("FROM sales_process sp").WithArgs(1).WillReturnRows(respRows)
+
+	// 5) Comments query (empty) for client_id=10.
+	commentRows := sqlmock.NewRows([]string{"id", "client_id", "entity_type", "entity_id", "author", "body", "metadata", "created_at", "updated_at"})
+	mock.ExpectQuery("FROM comments").WithArgs(10).WillReturnRows(commentRows)
+
+	w := httptest.NewRecorder()
+	h.UpdateSalesProcess(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp SalesProcessResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.StageID == nil || *resp.StageID != 7 {
+		t.Fatalf("expected stage_id=7, got %#v", resp.StageID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestUpdateSalesProcess_LostFromUnconvertedLead_DeletesTemporaryClient(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -389,7 +482,7 @@ func TestUpdateSalesProcess_LostFromUnconvertedLead_DeletesTemporaryClient(t *te
 
 	// 1) UPDATE sales_process
 	mock.ExpectExec("UPDATE sales_process").
-		WithArgs(nil, nil, false, false, nil, 1).
+		WithArgs(nil, nil, false, false, nil, 1, nil).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// 2) client_id lookup for completed_at updates
@@ -713,6 +806,176 @@ func TestStartSalesProcess_PreExistingLead_NewClient_LinksLeadViaClientID(t *tes
 	}
 	if *resp.SalesProcess.LeadID != 5 {
 		t.Fatalf("expected lead_id=5 (pre-existing lead), got %d", *resp.SalesProcess.LeadID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestStartSalesProcess_ExistingProcessBackfillsNullStageID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	h := &Handler{DB: db}
+
+	initial := "2026-04-01"
+	sourceStageID := 9
+	clientID := 8
+	reqBody := StartSalesProcessRequest{
+		Name:               "Laura Beispiel",
+		Email:              "laura@example.com",
+		InitialContactDate: &initial,
+		ClientID:           &clientID,
+		SourceStageID:      &sourceStageID,
+	}
+	b, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/api/sales/start", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+
+	// 1) Existing client details lookup.
+	mock.ExpectQuery("SELECT name, phone, source").
+		WithArgs(clientID).
+		WillReturnRows(sqlmock.NewRows([]string{"name", "phone", "source"}).
+			AddRow("Laura Beispiel", sql.NullString{Valid: false}, sql.NullString{String: "organic", Valid: true}))
+
+	// 2) No active contract.
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs(clientID).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	// 3) Begin tx.
+	mock.ExpectBegin()
+
+	// 4) Backfill client status.
+	mock.ExpectExec("UPDATE clients").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// 5) sales_process insert conflicts (no row returned).
+	mock.ExpectQuery("INSERT INTO sales_process").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	// 6) Reuse existing sales_process id=15.
+	mock.ExpectQuery("SELECT id FROM sales_process WHERE client_id = ").
+		WithArgs(clientID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(15))
+
+	// 7) Backfill stage_id only when currently NULL.
+	mock.ExpectExec("UPDATE sales_process SET stage_id = ").
+		WithArgs(&sourceStageID, 15).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 8) Commit.
+	mock.ExpectCommit()
+
+	// 9) Comments (empty).
+	mock.ExpectQuery("FROM comments").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "client_id", "entity_type", "entity_id", "author", "body", "metadata", "created_at", "updated_at"}))
+
+	// 10) Client detail.
+	mock.ExpectQuery("FROM clients").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "email", "phone", "source", "source_stage_id"}).
+			AddRow(8, "Laura Beispiel", "laura@example.com",
+				sql.NullString{Valid: false},
+				sql.NullString{String: "organic", Valid: true},
+				sql.NullInt64{Int64: 9, Valid: true}))
+
+	h.StartSalesProcess(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp StartSalesProcessResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.SalesProcess.StageID == nil || *resp.SalesProcess.StageID != 9 {
+		t.Fatalf("expected stage_id=9, got %#v", resp.SalesProcess.StageID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestStartSalesProcess_ExistingProcessWithoutSourceStageID_DoesNotBackfill(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	h := &Handler{DB: db}
+
+	initial := "2026-04-01"
+	clientID := 8
+	reqBody := StartSalesProcessRequest{
+		Name:               "Laura Beispiel",
+		InitialContactDate: &initial,
+		ClientID:           &clientID,
+	}
+	b, _ := json.Marshal(reqBody)
+	req := httptest.NewRequest(http.MethodPost, "/api/sales/start", bytes.NewReader(b))
+	w := httptest.NewRecorder()
+
+	// 1) Existing client details lookup.
+	mock.ExpectQuery("SELECT name, phone, source").
+		WithArgs(clientID).
+		WillReturnRows(sqlmock.NewRows([]string{"name", "phone", "source"}).
+			AddRow("Laura Beispiel", sql.NullString{Valid: false}, sql.NullString{String: "organic", Valid: true}))
+
+	// 2) No active contract.
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs(clientID).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	// 3) Begin tx.
+	mock.ExpectBegin()
+
+	// 4) Backfill client status.
+	mock.ExpectExec("UPDATE clients").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// 5) sales_process insert conflicts (no row returned).
+	mock.ExpectQuery("INSERT INTO sales_process").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	// 6) Reuse existing sales_process id=15.
+	mock.ExpectQuery("SELECT id FROM sales_process WHERE client_id = ").
+		WithArgs(clientID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(15))
+
+	// 7) Commit (no stage backfill update expected because SourceStageID is nil).
+	mock.ExpectCommit()
+
+	// 8) Comments (empty).
+	mock.ExpectQuery("FROM comments").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "client_id", "entity_type", "entity_id", "author", "body", "metadata", "created_at", "updated_at"}))
+
+	// 9) Client detail.
+	mock.ExpectQuery("FROM clients").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "email", "phone", "source", "source_stage_id"}).
+			AddRow(8, "Laura Beispiel", "laura@example.com",
+				sql.NullString{Valid: false},
+				sql.NullString{String: "organic", Valid: true},
+				sql.NullInt64{Valid: false}))
+
+	h.StartSalesProcess(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp StartSalesProcessResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.SalesProcess.StageID != nil {
+		t.Fatalf("expected nil stage_id, got %#v", resp.SalesProcess.StageID)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/db/seeds/dev_seed.sql
+++ b/db/seeds/dev_seed.sql
@@ -166,24 +166,8 @@ sp_max AS (
   FROM maxc m, s, seed_dates sd
   RETURNING id, client_id
 ),
--- Moritz: placeholder for the old/previous contract (imported-style)
-sp_moritz_old AS (
-  INSERT INTO sales_process (
-    client_id, stage, follow_up_date, follow_up_result, closed, revenue,
-    stage_id, created_at, updated_at, is_imported_placeholder
-  )
-  SELECT mo.id, NULL, NULL, NULL, NULL, NULL, NULL,
-         ((CURRENT_DATE - INTERVAL '11 months')::date - INTERVAL '1 day')::timestamp,
-         ((CURRENT_DATE - INTERVAL '11 months')::date - INTERVAL '1 day')::timestamp,
-         TRUE
-  FROM moritz mo
-  RETURNING id, client_id
-),
--- Moritz: follow-up done, not closed (FollowUp)
 sp_moritz AS (
   INSERT INTO sales_process (client_id, stage, follow_up_date, follow_up_result, closed, revenue, stage_id, created_at)
-  -- For a contract to exist, the sales process must be completed (closed).
-  -- Keep completion before contract created_at/start_date.
   SELECT mo.id,
          'closed',
          sd.moritz_completed_at,
@@ -236,7 +220,6 @@ sp_imported_fixture AS (
   RETURNING id, client_id
 ),
 
--- Contract with explicit end_date (not matching start + duration)
 contract_explicit_enddate AS (
   INSERT INTO contracts (client_id, sales_process_id, start_date, end_date, duration_months, revenue_total, payment_frequency, created_at)
   SELECT se.client_id,
@@ -275,30 +258,29 @@ contract_max AS (
   RETURNING id
 ),
 contract_moritz AS (
-  -- Previous contract: linked to a placeholder sales process (imported-style, so chain history is visible)
   INSERT INTO contracts (client_id, sales_process_id, start_date, duration_months, revenue_total, payment_frequency, created_at)
-  SELECT mo.id,
-         smo.id,
-         (CURRENT_DATE - INTERVAL '11 months')::date,
-         12,
-         12000,
-         'bi-yearly',
-         ((CURRENT_DATE - INTERVAL '11 months')::date - INTERVAL '1 day')::timestamptz
-  FROM moritz mo, sp_moritz_old smo
+  SELECT sm.client_id,
+    sm.id,
+    (CURRENT_DATE - INTERVAL '11 months')::date,
+    12,
+    12000,
+    'bi-yearly',
+    ((CURRENT_DATE - INTERVAL '11 months')::date - INTERVAL '1 day')::timestamptz
+  FROM sp_moritz sm
   RETURNING id
 ),
 contract_moritz_ext AS (
   INSERT INTO contracts (client_id, sales_process_id, start_date, duration_months, revenue_total, payment_frequency, created_at)
   SELECT sm.client_id,
-         sm.id,
-         sd.moritz_ext_contract_start,
-         12,
-         12000,
-         'bi-yearly',
-         (CURRENT_DATE::timestamp)
+    sm.id,
+    sd.moritz_ext_contract_start,
+    12,
+    12000,
+    'bi-yearly',
+    (CURRENT_DATE::timestamp)
   FROM sp_moritz sm, seed_dates sd
   RETURNING id
-      ),
+),
       contract_imported_fixture AS (
         INSERT INTO contracts (client_id, sales_process_id, start_date, duration_months, revenue_total, payment_frequency, created_at)
         SELECT spif.client_id,


### PR DESCRIPTION
- PATCH /sales/{id}: preserve stageId in form state when opening steps 3 & 4 (handleEnterResult, handleEnterClosing now copy entry.stage_id)
- GET /sales: return COALESCE(sp.stage_id, cl.source_stage_id) so records created without an explicit stage_id still resolve via the client fallback

<!--
PR template for Sales Assistant Backend
This template reminds contributors/maintainers to add the release label required by the release workflow.
-->

# Pull Request

Short summary (one or two lines):

Describe the change and why it is needed.

## Checklist

- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation if needed

**DB Migration** (tick exactly one):

- [x] No DB migrations in this PR
- [ ] Contains DB migration → Neon backup branch created, will run `goose up` manually after deploy

IMPORTANT: If this PR should trigger a release when merged to `master`, add one of the following labels to the PR (maintainers may add the label before merge):

- `major` — for breaking changes (bump MAJOR)
- `minor` — for new backward-compatible features (bump MINOR)
- `patch` — for bugfixes or small changes (bump PATCH)

The release workflow requires an explicit release label. If no label is present the release job will fail. If you are unsure which label to use, ask in the PR.

## Related issues

Links to issues, if any.
