### PR TITLE
fix: stage_id now correctly propagates through client/sales process l…

### DIFF
--- a/api/clients.go
+++ b/api/clients.go
@@ -428,16 +428,19 @@ func (h *Handler) UpdateClient(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Detect whether source_stage_id was explicitly provided (including explicit null = unlink).
+	_, sourceStageIDProvided := raw["source_stage_id"]
+
 	query := `
 		UPDATE clients
 		SET name = COALESCE($1, name),
 			email = COALESCE($2, email),
 			phone = COALESCE($3, phone),
 			source = COALESCE($4, source),
-			source_stage_id = COALESCE($5, source_stage_id),
-			status = COALESCE($6, status),
-			completed_at = $7
-		WHERE id = $8
+			source_stage_id = CASE WHEN $5 THEN $6::int ELSE source_stage_id END,
+			status = COALESCE($7, status),
+			completed_at = $8
+		WHERE id = $9
 	`
 
 	_, err = h.DB.Exec(
@@ -446,6 +449,7 @@ func (h *Handler) UpdateClient(w http.ResponseWriter, r *http.Request) {
 		nullStr(updated.Email),
 		nullStr(updated.Phone),
 		nullStr(updated.Source),
+		sourceStageIDProvided,
 		nullInt(updated.SourceStageID),
 		nullStr(updated.Status),
 		nullTime(completedAt),
@@ -461,6 +465,16 @@ func (h *Handler) UpdateClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// If source_stage_id was explicitly cleared, cascade: unlink all sales processes for this client.
+	if sourceStageIDProvided && updated.SourceStageID == nil {
+		if _, err := h.DB.Exec(`
+			UPDATE sales_process SET stage_id = NULL WHERE client_id = $1
+		`, id); err != nil {
+			log.Printf("❌ cascade stage_id clear failed for client %d: %v", id, err)
+			// non-fatal
+		}
+	}
+
 	// Sync the same contact fields to the linked converted lead (if any).
 	// Uses COALESCE so only non-empty values overwrite; blank fields are ignored.
 	if _, err := h.DB.Exec(`
@@ -470,13 +484,14 @@ func (h *Handler) UpdateClient(w http.ResponseWriter, r *http.Request) {
 			email           = COALESCE(NULLIF($2,''), email),
 			phone           = COALESCE(NULLIF($3,''), phone),
 			source          = COALESCE(NULLIF($4,''), source),
-			source_stage_id = COALESCE($5, source_stage_id)
-		WHERE converted_client_id = $6
+			source_stage_id = CASE WHEN $5 THEN $6::int ELSE source_stage_id END
+		WHERE converted_client_id = $7
 	`,
 		updated.Name,
 		updated.Email,
 		updated.Phone,
 		updated.Source,
+		sourceStageIDProvided,
 		nullInt(updated.SourceStageID),
 		id,
 	); err != nil {

--- a/api/clients_unit_test.go
+++ b/api/clients_unit_test.go
@@ -619,3 +619,88 @@ func TestCreateClient_CommentInsertFailsNonFatal(t *testing.T) {
 		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+// ── UpdateClient: explicit null source_stage_id cascades to sales_process ────
+
+func TestUpdateClient_ClearsSourceStageID_CascadesToSalesProcess(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT completed_at FROM clients").
+		WillReturnRows(sqlmock.NewRows([]string{"completed_at"}).AddRow(nil))
+	mock.ExpectExec("UPDATE clients").WillReturnResult(sqlmock.NewResult(1, 1))
+	// Cascade: clear stage_id on sales_process
+	mock.ExpectExec("UPDATE sales_process").WillReturnResult(sqlmock.NewResult(1, 1))
+	// Lead sync
+	mock.ExpectExec("UPDATE leads").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	h := &Handler{DB: db}
+	body := bytes.NewReader([]byte(`{"source_stage_id":null}`))
+	req := httptest.NewRequest(http.MethodPatch, "/api/clients/1", body)
+	w := httptest.NewRecorder()
+	h.UpdateClient(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestUpdateClient_SetSourceStageID_DoesNotCascade(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT completed_at FROM clients").
+		WillReturnRows(sqlmock.NewRows([]string{"completed_at"}).AddRow(nil))
+	mock.ExpectExec("UPDATE clients").WillReturnResult(sqlmock.NewResult(1, 1))
+	// No cascade UPDATE sales_process expected
+	mock.ExpectExec("UPDATE leads").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	h := &Handler{DB: db}
+	body := bytes.NewReader([]byte(`{"source_stage_id":5}`))
+	req := httptest.NewRequest(http.MethodPatch, "/api/clients/1", body)
+	w := httptest.NewRecorder()
+	h.UpdateClient(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations (unexpected cascade): %v", err)
+	}
+}
+
+func TestUpdateClient_OmittedSourceStageID_DoesNotCascade(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT completed_at FROM clients").
+		WillReturnRows(sqlmock.NewRows([]string{"completed_at"}).AddRow(nil))
+	mock.ExpectExec("UPDATE clients").WillReturnResult(sqlmock.NewResult(1, 1))
+	// No cascade UPDATE sales_process expected
+	mock.ExpectExec("UPDATE leads").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	h := &Handler{DB: db}
+	body := bytes.NewReader([]byte(`{"name":"Alice"}`))
+	req := httptest.NewRequest(http.MethodPatch, "/api/clients/1", body)
+	w := httptest.NewRecorder()
+	h.UpdateClient(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations (unexpected cascade): %v", err)
+	}
+}

--- a/api/sales.go
+++ b/api/sales.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -83,7 +84,7 @@ func (h *Handler) ListSalesProcesses(w http.ResponseWriter, r *http.Request) {
 		sp.follow_up_result,
 		sp.closed,
 		CASE WHEN COALESCE(sp.closed, false) THEN sp.revenue ELSE NULL END AS revenue,
-		COALESCE(sp.stage_id, cl.source_stage_id) AS stage_id,
+		sp.stage_id AS stage_id,
 		sp.lead_id
 	FROM sales_process sp
 	JOIN clients cl ON cl.id = sp.client_id
@@ -214,12 +215,29 @@ func (h *Handler) UpdateSalesProcess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Read raw body once so we can distinguish:
+	// - missing stage_id (leave unchanged)
+	// - stage_id: null (clear)
+	// - stage_id: <int> (set)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read request body", http.StatusBadRequest)
+		return
+	}
+
 	// Use the update request type that can carry contract details
 	var sp SalesProcessUpdateRequest
-	if err := json.NewDecoder(r.Body).Decode(&sp); err != nil {
+	if err := json.Unmarshal(body, &sp); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	_, stageIDProvided := raw["stage_id"]
 
 	// ---------- NORMALIZATION ----------
 	// If the follow-up did not happen (no-show), the process cannot be closed/won.
@@ -266,7 +284,10 @@ func (h *Handler) UpdateSalesProcess(w http.ResponseWriter, r *http.Request) {
 			WHEN $4 IS FALSE THEN NULL
 			ELSE revenue
 		END,
-		stage_id             = COALESCE($7, stage_id),
+		stage_id             = CASE
+			WHEN $7 THEN $8::int
+			ELSE stage_id
+		END,
 		stage = CASE
 			-- A no-show ends the process (UI can’t reschedule), mark as lost.
 			WHEN COALESCE($3, follow_up_result) IS FALSE THEN 'lost'
@@ -286,6 +307,7 @@ func (h *Handler) UpdateSalesProcess(w http.ResponseWriter, r *http.Request) {
 		sp.Closed,
 		sp.Revenue,
 		id,
+		stageIDProvided,
 		sp.StageID,
 	)
 

--- a/api/sales_unit_test.go
+++ b/api/sales_unit_test.go
@@ -288,7 +288,7 @@ func TestUpdateSalesProcess_NoShowForcesClosedFalseAndClearsCompletedAt(t *testi
 
 	// 1) UPDATE sales_process
 	mock.ExpectExec("UPDATE sales_process").
-		WithArgs(nil, nil, false, false, nil, 1, nil).
+		WithArgs(nil, nil, false, false, nil, 1, false, nil).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// 2) Load client_id for completed_at updates
@@ -389,7 +389,7 @@ func TestUpdateSalesProcess_WithStageID_UpdatesStageLink(t *testing.T) {
 
 	// 1) UPDATE sales_process includes $7 stage_id parameter.
 	mock.ExpectExec("UPDATE sales_process").
-		WithArgs(nil, nil, nil, nil, nil, 1, sqlmock.AnyArg()).
+		WithArgs(nil, nil, nil, nil, nil, 1, true, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// 2) Resolve client_id for downstream sync.
@@ -462,6 +462,95 @@ func TestUpdateSalesProcess_WithStageID_UpdatesStageLink(t *testing.T) {
 	}
 }
 
+func TestUpdateSalesProcess_WithStageIDNull_ClearsStageLink(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	h := &Handler{DB: db}
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/sales/1", bytes.NewReader([]byte(`{"stage_id":null}`)))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	// 1) UPDATE sales_process explicitly clears stage_id via $8=NULL.
+	mock.ExpectExec("UPDATE sales_process").
+		WithArgs(nil, nil, nil, nil, nil, 1, true, nil).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 2) Resolve client_id for downstream sync.
+	mock.ExpectQuery("SELECT client_id FROM sales_process WHERE id = ").
+		WithArgs(1).
+		WillReturnRows(sqlmock.NewRows([]string{"client_id"}).AddRow(10))
+
+	// 3) Sync client status.
+	mock.ExpectExec("UPDATE clients c").
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 4) Return updated row with stage_id=NULL.
+	respCols := []string{
+		"id",
+		"client_id",
+		"client_name",
+		"client_email",
+		"client_phone",
+		"client_source",
+		"completed_at",
+		"stage",
+		"initial_contact_date",
+		"follow_up_date",
+		"follow_up_result",
+		"closed",
+		"revenue",
+		"stage_id",
+	}
+	respRows := sqlmock.NewRows(respCols).
+		AddRow(
+			1,
+			10,
+			"Client X",
+			sql.NullString{Valid: false},
+			sql.NullString{Valid: false},
+			sql.NullString{String: "paid", Valid: true},
+			sql.NullTime{Valid: false},
+			"follow_up",
+			"2026-03-01",
+			"2026-03-03",
+			sql.NullBool{Valid: false},
+			sql.NullBool{Valid: false},
+			sql.NullFloat64{Valid: false},
+			sql.NullInt64{Valid: false},
+		)
+	mock.ExpectQuery("FROM sales_process sp").WithArgs(1).WillReturnRows(respRows)
+
+	// 5) Comments query (empty) for client_id=10.
+	commentRows := sqlmock.NewRows([]string{"id", "client_id", "entity_type", "entity_id", "author", "body", "metadata", "created_at", "updated_at"})
+	mock.ExpectQuery("FROM comments").WithArgs(10).WillReturnRows(commentRows)
+
+	w := httptest.NewRecorder()
+	h.UpdateSalesProcess(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp SalesProcessResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.StageID != nil {
+		t.Fatalf("expected stage_id=nil after unlink, got %#v", resp.StageID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestUpdateSalesProcess_LostFromUnconvertedLead_DeletesTemporaryClient(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -482,7 +571,7 @@ func TestUpdateSalesProcess_LostFromUnconvertedLead_DeletesTemporaryClient(t *te
 
 	// 1) UPDATE sales_process
 	mock.ExpectExec("UPDATE sales_process").
-		WithArgs(nil, nil, false, false, nil, 1, nil).
+		WithArgs(nil, nil, false, false, nil, 1, false, nil).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// 2) client_id lookup for completed_at updates

--- a/api/stages_test.go
+++ b/api/stages_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -553,3 +554,73 @@ func TestListStageParticipants_RealTimestampRows(t *testing.T) {
 
 // --- helpers for pointer types ---
 func ptrF(f float64) *float64 { return &f }
+
+// ── DeleteStageParticipant ────────────────────────────────────────────────────
+
+func stageParticipantRequest(method, stageID, participantID string) *http.Request {
+	req := httptest.NewRequest(method, "/api/stages/"+stageID+"/participants/"+participantID, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", stageID)
+	rctx.URLParams.Add("participant_id", participantID)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestDeleteStageParticipant_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("DELETE FROM stage_participants").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	h := &api.Handler{DB: db}
+	w := httptest.NewRecorder()
+	h.DeleteStageParticipant(w, stageParticipantRequest(http.MethodDelete, "1", "42"))
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestDeleteStageParticipant_NotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("DELETE FROM stage_participants").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	h := &api.Handler{DB: db}
+	w := httptest.NewRecorder()
+	h.DeleteStageParticipant(w, stageParticipantRequest(http.MethodDelete, "1", "99"))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteStageParticipant_DBError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("DELETE FROM stage_participants").
+		WillReturnError(fmt.Errorf("db down"))
+
+	h := &api.Handler{DB: db}
+	w := httptest.NewRecorder()
+	h.DeleteStageParticipant(w, stageParticipantRequest(http.MethodDelete, "1", "1"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
…ifecycle and vice versa

<!--
PR template for Sales Assistant Backend
This template reminds contributors/maintainers to add the release label required by the release workflow.
-->

# Pull Request

Short summary (one or two lines):

Describe the change and why it is needed.

## Checklist

- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation if needed

**DB Migration** (tick exactly one):

- [x] No DB migrations in this PR
- [ ] Contains DB migration → Neon backup branch created, will run `goose up` manually after deploy

IMPORTANT: If this PR should trigger a release when merged to `master`, add one of the following labels to the PR (maintainers may add the label before merge):

- `major` — for breaking changes (bump MAJOR)
- `minor` — for new backward-compatible features (bump MINOR)
- `patch` — for bugfixes or small changes (bump PATCH)

The release workflow requires an explicit release label. If no label is present the release job will fail. If you are unsure which label to use, ask in the PR.

## Related issues

Links to issues, if any.
