### PR TITLE
fix: saving contracts broken by deferrable cashflow constraint

### DIFF
--- a/internal/db/migrations/20260610101600_restore_cashflow_unique_index_non_deferrable.down.sql
+++ b/internal/db/migrations/20260610101600_restore_cashflow_unique_index_non_deferrable.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS ux_cashflow_contract_due;
+CREATE UNIQUE INDEX ux_cashflow_contract_due ON cashflow_entries (contract_id, due_date);

--- a/internal/db/migrations/20260610101600_restore_cashflow_unique_index_non_deferrable.up.sql
+++ b/internal/db/migrations/20260610101600_restore_cashflow_unique_index_non_deferrable.up.sql
@@ -1,0 +1,7 @@
+-- The deferrable variant was applied to some DBs as a table constraint (not just
+-- an index), which breaks ON CONFLICT (contract_id, due_date) DO NOTHING.
+-- Drop the constraint (if present), then drop the bare index (if present),
+-- and recreate as a plain non-deferrable unique index.
+ALTER TABLE cashflow_entries DROP CONSTRAINT IF EXISTS ux_cashflow_contract_due;
+DROP INDEX IF EXISTS ux_cashflow_contract_due;
+CREATE UNIQUE INDEX ux_cashflow_contract_due ON cashflow_entries (contract_id, due_date);


### PR DESCRIPTION
<!--
PR template for Sales Assistant Backend
This template reminds contributors/maintainers to add the release label required by the release workflow.
-->

# Pull Request

Short summary (one or two lines):

Describe the change and why it is needed.

## Checklist

- [ ] I have added/updated tests where appropriate
- [ ] I have updated documentation if needed

**DB Migration** (tick exactly one):

- [ ] No DB migrations in this PR
- [x] Contains DB migration → Neon backup branch created before deploy. Migrations run automatically on startup.

IMPORTANT: If this PR should trigger a release when merged to `master`, add one of the following labels to the PR (maintainers may add the label before merge):

- `major` — for breaking changes (bump MAJOR)
- `minor` — for new backward-compatible features (bump MINOR)
- `patch` — for bugfixes or small changes (bump PATCH)

The release workflow requires an explicit release label. If no label is present the release job will fail. If you are unsure which label to use, ask in the PR.

## Related issues

Links to issues, if any.
